### PR TITLE
Update bastion instance type to t3.medium

### DIFF
--- a/aws/cloudformation/rdp_bastion.yaml
+++ b/aws/cloudformation/rdp_bastion.yaml
@@ -40,7 +40,7 @@ Parameters:
   pInstanceType:
     Description: EC2 instance type
     Type: String
-    Default: "t3.micro"
+    Default: "t3.medium"
   pSshLocation:
     Description: The IP address range that can SSH to the EC2 instance
     Type: String


### PR DESCRIPTION
apps crash due to chrome using more memory