### PR TITLE
Fixing the Transit Gateway Attachment route table issue

### DIFF
--- a/aws/cloudformation/privatelink-with-network-firewall.yaml
+++ b/aws/cloudformation/privatelink-with-network-firewall.yaml
@@ -553,7 +553,7 @@ Resources:
     Properties:
       AutoAcceptSharedAttachments: disable
       DnsSupport: enable
-      DefaultRouteTableAssociation: enable
+      DefaultRouteTableAssociation: disable
       DefaultRouteTablePropagation: enable
       Tags:
         - Key: Name


### PR DESCRIPTION
Fixing the following error when using the CloudFormation template:

```
Resource handler returned message: "Transit Gateway Attachment tgw-attach-07c75a7e7bcaa2836 is already associated to a route table. (Service: Ec2, Status Code: 400, Request ID: 192249dd-2020-42b4-94fb-918001d34f1a)" (RequestToken: 787017e0-9d72-29b5-b0b8-ad60c7ab3810, HandlerErrorCode: GeneralServiceException)
```