### PR TITLE
MySQL engine version bump

### DIFF
--- a/aws/cloudformation/customer-vpc.yaml
+++ b/aws/cloudformation/customer-vpc.yaml
@@ -952,7 +952,7 @@ Resources:
           - 0
           - Fn::GetAZs: ""
       Engine: mysql
-      EngineVersion: 8.0.33
+      EngineVersion: 8.0.45
       MasterUsername: admin
       MasterUserPassword: redhat123
       Port: "3306"


### PR DESCRIPTION
CloudFormation stack is failing because the MySQL Engine version isn't available anymore on AWS. Switching to the latest one in the 8.0 series (8.0.45) fixes this issue.